### PR TITLE
Add Firo to license

### DIFF
--- a/COPYING
+++ b/COPYING
@@ -1,6 +1,7 @@
 The MIT License (MIT)
 
 Copyright (c) 2016-2023 The Kiirocoin Core developers
+Copyright (c) 2016-2023 The Firo Core developers
 Copyright (c) 2009-2023 The Bitcoin Core developers
 
 Permission is hereby granted, free of charge, to any person obtaining a copy


### PR DESCRIPTION
I see Firo is mentioned in the "code contributors" section, but not in the actual license. The MIT specifically instructs to retain the copyright notice of copyright holders, but Firo's notice is missing. This PR fixes the issue and makes the repository compliant.